### PR TITLE
fix: emit Markdown links in llms.txt

### DIFF
--- a/src/pages/llms.txt.ts
+++ b/src/pages/llms.txt.ts
@@ -2,6 +2,9 @@ import type { APIRoute } from 'astro'
 import { coverSongs, originalSongs, songUrl } from '@/lib/songs'
 import { PROFILE, SITE_DESCRIPTION, SITE_NAME, SITE_URL, SOCIALS, TAGLINE } from '@/lib/site'
 
+/** Escape brackets so titles like "[COVER] ..." stay valid Markdown link text. */
+const escapeLinkText = (text: string): string => text.replace(/([[\]])/g, '\\$1')
+
 /**
  * llms.txt, a plain-text digest of the whole site for language models.
  * See https://llmstxt.org/
@@ -14,7 +17,7 @@ export const GET: APIRoute = () => {
       `${SITE_NAME} adalah VTuber indie asal Indonesia bertema Kucing Bulan.`,
       `Tagline: "${TAGLINE}".`,
       `Fandom-nya bernama Rizuniverse dan fansnya disebut Sirius.`,
-      `Situs resmi: ${SITE_URL}`,
+      `Situs resmi: [${SITE_NAME}](${SITE_URL})`,
     ].join(' '),
 
     ['## Profil', ...PROFILE.map((item) => `- ${item.label}: ${item.value}`)].join('\n'),
@@ -26,21 +29,24 @@ export const GET: APIRoute = () => {
       ...originalSongs.map((song) =>
         [
           `### ${song.title}`,
-          `- Halaman lirik: ${songUrl(song.slug, SITE_URL)}`,
-          `- Deskripsi: ${song.description}`,
-          `- Video: ${song.projectLink}`,
+          `- [Halaman lirik](${songUrl(song.slug, SITE_URL)}): ${song.description}`,
+          `- [Video](${song.projectLink})`,
         ].join('\n'),
       ),
     ].join('\n'),
 
     [
       `## Lagu Cover (${coverSongs.length})`,
-      ...coverSongs.map((song) => `- ${song.title}, ${song.description} (${song.projectLink})`),
+      ...coverSongs.map((song) => `- [${escapeLinkText(song.title)}](${song.projectLink})`),
     ].join('\n'),
 
-    ['## Tautan Resmi', ...SOCIALS.map((s) => `- ${s.name}: ${s.url}`)].join('\n'),
+    ['## Tautan Resmi', ...SOCIALS.map((s) => `- [${s.name}](${s.url})`)].join('\n'),
 
-    ['## Halaman', `- Beranda: ${SITE_URL}/`, `- Sitemap: ${SITE_URL}/sitemap-index.xml`].join('\n'),
+    [
+      '## Halaman',
+      `- [Beranda](${SITE_URL}/)`,
+      `- [Sitemap](${SITE_URL}/sitemap-index.xml)`,
+    ].join('\n'),
   ]
 
   return new Response(`${sections.join('\n\n')}\n`, {


### PR DESCRIPTION
Lighthouse's agent-accessibility audit reported "File does not appear to contain any links" because llms.txt listed bare URLs, which the audit does not recognize. Wrap every URL in Markdown link syntax.

Also collapse the duplicated title/description pair on cover songs, and escape brackets in link text so titles like "[COVER] ..." stay valid.